### PR TITLE
bug: 소셜로그인 회원가입 이후 작동 문제 해결

### DIFF
--- a/src/main/java/com/ayno/aynobe/config/security/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/ayno/aynobe/config/security/service/CustomOAuth2UserService.java
@@ -34,7 +34,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         OAuthAttributes attributes = OAuthAttributes.of(provider, oAuth2User.getAttributes());
 
         // DB 저장 or 조회
-        LinkedAccount linked = linkedAccountRepository.findByProviderAndProviderId(
+        LinkedAccount linked = linkedAccountRepository.findWithUser(
                         attributes.getProvider(),
                         attributes.getProviderId()
                 )

--- a/src/main/java/com/ayno/aynobe/repository/LinkedAccountRepository.java
+++ b/src/main/java/com/ayno/aynobe/repository/LinkedAccountRepository.java
@@ -2,9 +2,17 @@ package com.ayno.aynobe.repository;
 
 import com.ayno.aynobe.entity.LinkedAccount;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
 public interface LinkedAccountRepository extends JpaRepository<LinkedAccount, Long> {
+    @Query("""
+    select la from LinkedAccount la
+    join fetch la.user u
+    where la.provider = :provider and la.providerId = :providerId
+    """)
+    Optional<LinkedAccount> findWithUser(String provider, String providerId);
+
     Optional<LinkedAccount> findByProviderAndProviderId(String provider, String providerId);
 }


### PR DESCRIPTION
### PR: OAuth2 재로그인 `LazyInitializationException` 수정 — `LinkedAccount.user` 즉시 로딩(fetch join)

**요약**
소셜 **두 번째 로그인(재로그인)** 시 `LazyInitializationException: Could not initialize proxy - no session`이 발생하던 문제를 해결했습니다.
`LinkedAccount`만 조회하고 `user` 연관을 **LAZY 프록시**로 남긴 채 필터 단계에서 `getUsername()`에 접근하면서, **영속성 컨텍스트(하이버네이트 세션)가 이미 닫힌 뒤** 프록시 초기화가 시도되어 예외가 발생했습니다. 이를 **fetch join**으로 `user`를 함께 로딩하도록 변경했습니다.

---

## 현상

* 첫 소셜 로그인: 정상
* **두 번째(이후) 소셜 로그인**: 인증 처리 중 `LazyInitializationException` 발생

## 원인(설명용)

* 기존 조회: `Optional<LinkedAccount> findByProviderAndProviderId(...)`
  → `LinkedAccount.user`는 `@ManyToOne(fetch = LAZY)`라 **프록시(껍데기)** 로 반환됨.
* 인증 필터 체인에서 `CustomUserDetails.getUsername()` → 내부적으로 `user.getUsername()` 호출
  → 프록시가 **실제 로딩**을 시도하지만, 이미 **영속성 컨텍스트(하이버네이트 세션)** 가 **닫힌 시점**이라 DB 접근 불가 → 예외
* **첫 로그인은 왜 됐나?**
  첫 로그인 흐름에선 가입/연결 로직에서 `User`를 **직접 생성/저장한 실제 객체**를 사용했기 때문(프록시가 아님).

## 수정 내용

1. **Repository:** `user`를 즉시 로딩하는 메소드 추가

```java
@Query("""
select la from LinkedAccount la
join fetch la.user u
where la.provider = :provider and la.providerId = :providerId
""")
Optional<LinkedAccount> findWithUser(String provider, String providerId);
```

2. **Service:** 재로그인 경로에서 위 메소드 사용

```java
LinkedAccount linked = linkedAccountRepository.findWithUser(
        attributes.getProvider(), attributes.getProviderId()
).orElseGet(() -> {
    // (신규 가입 분기) user 생성/조회 → linkedAccount 저장
    // …생략…
    return linkedAccountRepository.save(LinkedAccount.builder()
            .provider(attributes.getProvider())
            .providerId(attributes.getProviderId())
            .user(user)
            .build());
});
return new CustomUserDetails(linked.getUser()); // 이미 초기화된 user
```

> 선택: `loadUser()` 메소드에 `@Transactional` 부여(가입 분기 save가 있어 권장).

## 왜 이게 해결인가?

* `fetch join`으로 **조회 시점에 `user` 실체를 메모리에 로딩** → Principal에 **프록시가 아닌 초기화된 `User`** 가 들어감
* 이후 필터 체인(트랜잭션 밖)에서 `getUsername()`을 호출해도 **추가 초기화가 필요 없음** → 예외 소멸

## 테스트 시나리오

* [x] 기존 계정으로 **재로그인** 시 예외 미발생 확인
* [x] 신규 소셜 로그인(가입 경로) 정상 → 이어서 재로그인도 정상
* [x] 쿠키(`accessToken`, `refreshToken`) 세팅 및 인증 API 호출 정상
* [x] 서버 로그에 `LazyInitializationException` 미발생

## 영향/리스크

* 쿼리 경로만 변경(스키마/설정 변경 없음)
* 성능: 필요 시점에만 `join fetch` 1회 추가로 오히려 안정적(N+1 예방)

## 후속 권장(선택)

* 장기적으로는 `CustomUserDetails`에 **엔티티 대신 값(id/username/roles)** 만 보관하는 구조로 리팩터링하면 유사 이슈를 원천 차단 가능.

