### PR TITLE
feature : 워크플로우 좋아요 API 추가 (/api/reaction), 멱등 처리 및 카운트 증감

### DIFF
--- a/src/main/java/com/ayno/aynobe/config/security/SecurityConfig.java
+++ b/src/main/java/com/ayno/aynobe/config/security/SecurityConfig.java
@@ -69,6 +69,8 @@ public class SecurityConfig {
                         .requestMatchers("/api/interests/**", "/api/jobs/**").hasAnyRole("ADMIN","USER")
                         .requestMatchers(HttpMethod.GET, "/api/workflows/**").permitAll()
                         .requestMatchers("/api/users/**", "/api/workflows/**").hasRole("USER")
+                        .requestMatchers(HttpMethod.GET, "/api/reaction/**").permitAll()
+                        .requestMatchers("/api/reaction/**").hasRole("USER")
                         .anyRequest().authenticated())
                 .oauth2Login(oauth2 -> oauth2
                 .userInfoEndpoint(userInfo -> userInfo

--- a/src/main/java/com/ayno/aynobe/controller/ReactionController.java
+++ b/src/main/java/com/ayno/aynobe/controller/ReactionController.java
@@ -1,0 +1,56 @@
+package com.ayno.aynobe.controller;
+
+import com.ayno.aynobe.config.security.CustomUserDetails;
+import com.ayno.aynobe.dto.common.Response;
+import com.ayno.aynobe.dto.reaction.WorkflowLikeResponseDTO;
+import com.ayno.aynobe.entity.User;
+import com.ayno.aynobe.service.ReactionService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.annotation.Nullable;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Reaction", description = "리엑션 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/reaction")
+public class ReactionController {
+
+    private final ReactionService reactionService;
+
+    @Operation(summary = "워크플로우 좋아요 상태 조회(로그인 없어도 가능)")
+    @GetMapping("/workflows/{workflowId}/like")
+    public ResponseEntity<Response<WorkflowLikeResponseDTO>> getLike(
+            @AuthenticationPrincipal @Nullable CustomUserDetails principal,
+            @PathVariable Long workflowId
+    ) {
+        User actor = (principal != null) ? principal.getUser() : null;
+        var res = reactionService.getWorkflowLike(actor, workflowId);
+        return ResponseEntity.ok(Response.success(res));
+    }
+
+    @Operation(summary = "워크플로우 좋아요")
+    @PostMapping("/workflows/{workflowId}/like")
+    public ResponseEntity<Response<WorkflowLikeResponseDTO>> like(
+            @AuthenticationPrincipal CustomUserDetails principal,
+            @PathVariable Long workflowId
+    ) {
+        User actor = principal.getUser();
+        var res = reactionService.likeWorkflow(actor, workflowId);
+        return ResponseEntity.ok(Response.success(res));
+    }
+
+    @Operation(summary = "워크플로우 좋아요 취소")
+    @DeleteMapping("/workflows/{workflowId}/like")
+    public ResponseEntity<Response<WorkflowLikeResponseDTO>> unlike(
+            @AuthenticationPrincipal CustomUserDetails principal,
+            @PathVariable Long workflowId
+    ) {
+        User actor = principal.getUser();
+        var res = reactionService.unlikeWorkflow(actor, workflowId);
+        return ResponseEntity.ok(Response.success(res));
+    }
+}

--- a/src/main/java/com/ayno/aynobe/dto/reaction/WorkflowLikeResponseDTO.java
+++ b/src/main/java/com/ayno/aynobe/dto/reaction/WorkflowLikeResponseDTO.java
@@ -1,0 +1,21 @@
+package com.ayno.aynobe.dto.reaction;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(name = "WorkflowLikeResponse")
+public class WorkflowLikeResponseDTO {
+    @Schema(description = "워크플로우 ID", example = "123")
+    private Long workflowId;
+
+    @Schema(description = "해당 사용자가 좋아요 눌렀는지", example = "true")
+    private boolean liked;
+
+    @Schema(description = "전체 좋아요 수", example = "42")
+    private long likeCount;
+}

--- a/src/main/java/com/ayno/aynobe/entity/Reaction.java
+++ b/src/main/java/com/ayno/aynobe/entity/Reaction.java
@@ -14,8 +14,11 @@ import lombok.*;
                 @Index(name = "idx_reaction_target", columnList = "targetType, targetId, reactionType"),
                 @Index(name = "idx_reaction_user",   columnList = "userId, reactionType")
         })
-@Getter @Setter
-@NoArgsConstructor @AllArgsConstructor @Builder
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class Reaction extends BaseTimeEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/ayno/aynobe/repository/ReactionRepository.java
+++ b/src/main/java/com/ayno/aynobe/repository/ReactionRepository.java
@@ -1,10 +1,14 @@
 package com.ayno.aynobe.repository;
 
 import com.ayno.aynobe.entity.Reaction;
+import com.ayno.aynobe.entity.enums.ReactionType;
 import com.ayno.aynobe.entity.enums.TargetType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface ReactionRepository extends JpaRepository<Reaction, Long> {
 
@@ -12,4 +16,14 @@ public interface ReactionRepository extends JpaRepository<Reaction, Long> {
     @Query("delete from Reaction r " +
             "where r.targetType = :targetType and r.targetId = :targetId")
     void deleteByTargetTypeAndTargetId(TargetType targetType, Long targetId);
+
+    Optional<Reaction> findByUser_UserIdAndTargetTypeAndTargetIdAndReactionType(
+            Long userId, TargetType targetType, Long targetId, ReactionType reactionType);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("delete from Reaction r where r.user.userId = :userId and r.targetType = :targetType and r.targetId = :targetId and r.reactionType = :reactionType")
+    void deleteByUserAndTargetAndType(@Param("userId") Long userId,
+                                      @Param("targetType") TargetType targetType,
+                                      @Param("targetId") Long targetId,
+                                      @Param("reactionType") ReactionType reactionType);
 }

--- a/src/main/java/com/ayno/aynobe/repository/WorkflowRepository.java
+++ b/src/main/java/com/ayno/aynobe/repository/WorkflowRepository.java
@@ -7,6 +7,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -27,4 +30,10 @@ public interface WorkflowRepository extends JpaRepository<Workflow, Long> {
             "workflowSteps.tool"
     })
     Optional<Workflow> findWithAllByWorkflowId(Long workflowId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("update Workflow w " +
+            "set w.likeCount = w.likeCount + :delta " +
+            "where w.workflowId = :workflowId")
+    int updateLikeCount(@Param("workflowId") Long workflowId, @Param("delta") long delta);
 }

--- a/src/main/java/com/ayno/aynobe/service/ReactionService.java
+++ b/src/main/java/com/ayno/aynobe/service/ReactionService.java
@@ -1,0 +1,109 @@
+package com.ayno.aynobe.service;
+
+import com.ayno.aynobe.config.exception.CustomException;
+import com.ayno.aynobe.dto.reaction.WorkflowLikeResponseDTO;
+import com.ayno.aynobe.entity.Reaction;
+import com.ayno.aynobe.entity.User;
+import com.ayno.aynobe.entity.Workflow;
+import com.ayno.aynobe.entity.enums.ReactionType;
+import com.ayno.aynobe.entity.enums.TargetType;
+import com.ayno.aynobe.repository.ReactionRepository;
+import com.ayno.aynobe.repository.WorkflowRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ReactionService {
+
+    private final ReactionRepository reactionRepository;
+    private final WorkflowRepository workflowRepository;
+
+    @Transactional(readOnly = true)
+    public WorkflowLikeResponseDTO getWorkflowLike(User actor, Long workflowId) {
+        Workflow wf = workflowRepository.findById(workflowId)
+                .orElseThrow(() -> CustomException.notFound("존재하지 않는 워크플로우입니다."));
+
+        boolean liked = false;
+        if (actor != null) {
+            liked = reactionRepository.findByUser_UserIdAndTargetTypeAndTargetIdAndReactionType(
+                    actor.getUserId(), TargetType.WORKFLOW, workflowId, ReactionType.LIKE
+            ).isPresent();
+        }
+
+        return WorkflowLikeResponseDTO.builder()
+                .workflowId(wf.getWorkflowId())
+                .liked(liked)
+                .likeCount(wf.getLikeCount())
+                .build();
+    }
+
+    @Transactional
+    public WorkflowLikeResponseDTO likeWorkflow(User actor, Long workflowId) {
+        Workflow wf = workflowRepository.findById(workflowId)
+                .orElseThrow(() -> CustomException.notFound("존재하지 않는 워크플로우입니다."));
+
+        // 이미 눌렀으면 그대로 반환 (멱등)
+        var existed = reactionRepository.findByUser_UserIdAndTargetTypeAndTargetIdAndReactionType(
+                actor.getUserId(), TargetType.WORKFLOW, workflowId, ReactionType.LIKE);
+        if (existed.isPresent()) {
+            return WorkflowLikeResponseDTO.builder()
+                    .workflowId(workflowId)
+                    .liked(true)
+                    .likeCount(wf.getLikeCount())
+                    .build();
+        }
+
+        // 저장 + likeCount +1
+        Reaction r = Reaction.builder()
+                .user(actor)
+                .targetId(workflowId)
+                .targetType(TargetType.WORKFLOW)
+                .reactionType(ReactionType.LIKE)
+                .build();
+        reactionRepository.save(r);
+        workflowRepository.updateLikeCount(workflowId, 1);
+
+        // 최신 카운트 반환 위해 다시 조회
+        Workflow refreshed = workflowRepository.findById(workflowId)
+                .orElseThrow(() -> CustomException.notFound("존재하지 않는 워크플로우입니다."));
+
+        return WorkflowLikeResponseDTO.builder()
+                .workflowId(workflowId)
+                .liked(true)
+                .likeCount(refreshed.getLikeCount())
+                .build();
+    }
+
+    @Transactional
+    public WorkflowLikeResponseDTO unlikeWorkflow(User actor, Long workflowId) {
+        Workflow wf = workflowRepository.findById(workflowId)
+                .orElseThrow(() -> CustomException.notFound("존재하지 않는 워크플로우입니다."));
+
+        var existed = reactionRepository.findByUser_UserIdAndTargetTypeAndTargetIdAndReactionType(
+                actor.getUserId(), TargetType.WORKFLOW, workflowId, ReactionType.LIKE);
+
+        if (existed.isEmpty()) {
+            // 멱등: 이미 취소 상태면 그대로 반환
+            return WorkflowLikeResponseDTO.builder()
+                    .workflowId(workflowId)
+                    .liked(false)
+                    .likeCount(wf.getLikeCount())
+                    .build();
+        }
+
+        // 삭제 + likeCount -1 (하한 0은 UI에서만 고려, 서버는 단순 감소)
+        reactionRepository.deleteByUserAndTargetAndType(actor.getUserId(), TargetType.WORKFLOW, workflowId, ReactionType.LIKE);
+        workflowRepository.updateLikeCount(workflowId, -1);
+
+        Workflow refreshed = workflowRepository.findById(workflowId)
+                .orElseThrow(() -> CustomException.notFound("존재하지 않는 워크플로우입니다."));
+
+        return WorkflowLikeResponseDTO.builder()
+                .workflowId(workflowId)
+                .liked(false)
+                .likeCount(Math.max(0, refreshed.getLikeCount()))
+                .build();
+    }
+}


### PR DESCRIPTION
## 요약

* **좋아요 상태 조회(비로그인 허용)**, **좋아요(POST)**, **좋아요 취소(DELETE)** 구현
* 중복 좋아요 방지를 위한 **유니크 인덱스** 추가
* `Workflow.likeCount`를 **원자적 증감 쿼리**로 관리(동시성 안전)
* 라우팅을 **/api/reaction** 로 분리

---

## 변경 상세

### 1) 엔드포인트

Base: `/api/reaction`

* `GET  /api/reaction/workflows/{workflowId}/like`

  * 비로그인 허용, 현재 사용자 기준 `liked` 상태 + 전체 `likeCount` 반환
* `POST /api/reaction/workflows/{workflowId}/like`

  * 좋아요(멱등: 이미 좋아요면 그대로 결과 반환)
* `DELETE /api/reaction/workflows/{workflowId}/like`

  * 좋아요 취소(멱등: 이미 취소 상태면 그대로 결과 반환)

응답 공통 래핑: `Response.success(WorkflowLikeResponseDTO)`

### 2) DTO

```java
// WorkflowLikeResponseDTO
{
  "workflowId": 123,
  "liked": true,
  "likeCount": 42
}
```

### 3) Repository

* `ReactionRepository`

  * `findByUser_UserIdAndTargetTypeAndTargetIdAndReactionType(...)`
  * `@Modifying void deleteByUserAndTargetAndType(...)`  ← 널 리턴 이슈 방지
* `WorkflowRepository`

  * `@Modifying int updateLikeCount(Long workflowId, long delta)`  ← `likeCount` 증감

### 4) Service (ReactionService)

* `getWorkflowLike(actorOrNull, workflowId)`

  * 워크플로우 존재 확인 → `liked` 조회 → DTO 반환
* `likeWorkflow(actor, workflowId)`

  * Reaction 중복 검사 → 없으면 insert → `likeCount +1` → DTO
* `unlikeWorkflow(actor, workflowId)`

  * Reaction 존재 검사 → 있으면 delete → `likeCount -1` → DTO
* 예외: 워크플로우 미존재 시 `CustomException.notFound(...)`

### 5) Controller

```java
@RequestMapping("/api/reaction")
@GetMapping   ("/workflows/{workflowId}/like")   // 공개
@PostMapping  ("/workflows/{workflowId}/like")   // USER
@DeleteMapping("/workflows/{workflowId}/like")   // USER
```

### 6) 시큐리티

```java
.requestMatchers(HttpMethod.GET, "/api/reaction/**").permitAll()
.requestMatchers("/api/reaction/**").hasRole("USER")
```

(기존) `GET /api/workflows/**` 또한 `permitAll` 유지.

### 7) DB 마이그레이션

중복 좋아요 방지 유니크 인덱스:

```sql
CREATE UNIQUE INDEX IF NOT EXISTS UQ_REACTION_USER_TARGET_TYPE_ID_KIND
ON reaction(user_id, target_type, target_id, reaction_type);
```

### 8) 엔티티

`Reaction` (제공된 그대로 사용):

* `user`, `targetId`, `targetType(WORKFLOW|ARTIFACT)`, `reactionType(LIKE)`

---

## 샘플

### 좋아요 상태 조회 (공개)

```
GET /api/reaction/workflows/123/like
→ 200
{
  "status":"SUCCESS",
  "data":{"workflowId":123,"liked":false,"likeCount":41},
  "serverDateTime":"..."
}
```

### 좋아요

```
POST /api/reaction/workflows/123/like
Authorization: Bearer <USER>
→ 200
{
  "status":"SUCCESS",
  "data":{"workflowId":123,"liked":true,"likeCount":42},
  "serverDateTime":"..."
}
```

### 좋아요 취소

```
DELETE /api/reaction/workflows/123/like
Authorization: Bearer <USER>
→ 200
{
  "status":"SUCCESS",
  "data":{"workflowId":123,"liked":false,"likeCount":41},
  "serverDateTime":"..."
}
```

---

## 멱등 & 동시성

* **멱등성**: 이미 좋아요/이미 취소 상태에서 호출해도 동일 결과 반환
* **동시성**: `updateLikeCount(workflowId, ±1)`로 카운터를 원자적으로 조정
* 추후 싱크 필요 시 배치로 `reaction` 테이블 카운트와 `likeCount` 재동기화 가능

---

## 체크리스트

* [ ] 인덱스 생성(유니크) 적용
* [ ] 시큐리티 경로 반영(`/api/reaction/**`)
* [ ] Swagger에 3개 엔드포인트 노출/확인
* [ ] 로컬/H2 및 스테이징에서 멱등/동시성 간단 검증

---

## 후속

* 대상 확대: `ARTIFACT` 좋아요 동일 패턴 확장
* 향후 반응 타입 추가 시(`BOOKMARK`, `CLAP` 등) 인덱스 재활용 가능
