### PR TITLE
feature: 리액션 정리 — 워크플로우 좋아요 3종 제거, 결과물(Artifact) 좋아요 3종 신규 추가

### DIFF
--- a/src/main/java/com/ayno/aynobe/controller/ReactionController.java
+++ b/src/main/java/com/ayno/aynobe/controller/ReactionController.java
@@ -2,12 +2,10 @@ package com.ayno.aynobe.controller;
 
 import com.ayno.aynobe.config.security.CustomUserDetails;
 import com.ayno.aynobe.dto.common.Response;
-import com.ayno.aynobe.dto.reaction.WorkflowLikeResponseDTO;
-import com.ayno.aynobe.entity.User;
+import com.ayno.aynobe.dto.reaction.ArtifactLikeResponseDTO;
 import com.ayno.aynobe.service.ReactionService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.annotation.Nullable;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -21,36 +19,37 @@ public class ReactionController {
 
     private final ReactionService reactionService;
 
-    @Operation(summary = "워크플로우 좋아요 상태 조회(로그인 없어도 가능)")
-    @GetMapping("/workflows/{workflowId}/like")
-    public ResponseEntity<Response<WorkflowLikeResponseDTO>> getLike(
-            @AuthenticationPrincipal @Nullable CustomUserDetails principal,
-            @PathVariable Long workflowId
+    @Operation(summary = "결과물 좋아요 상태 조회", description = "로그인 없이도 조회 가능")
+    @GetMapping("/artifacts/{artifactId}/like")
+    public ResponseEntity<Response<ArtifactLikeResponseDTO>> getArtifactLike(
+            @AuthenticationPrincipal CustomUserDetails principal,
+            @PathVariable Long artifactId
     ) {
-        User actor = (principal != null) ? principal.getUser() : null;
-        var res = reactionService.getWorkflowLike(actor, workflowId);
-        return ResponseEntity.ok(Response.success(res));
+        var actor = (principal != null) ? principal.getUser() : null;
+        return ResponseEntity.ok(Response.success(
+                reactionService.getArtifactLike(actor, artifactId)
+        ));
     }
 
-    @Operation(summary = "워크플로우 좋아요")
-    @PostMapping("/workflows/{workflowId}/like")
-    public ResponseEntity<Response<WorkflowLikeResponseDTO>> like(
+    @Operation(summary = "결과물 좋아요", description = "멱등 — 이미 좋아요면 그대로 반환")
+    @PostMapping("/artifacts/{artifactId}/like")
+    public ResponseEntity<Response<ArtifactLikeResponseDTO>> likeArtifact(
             @AuthenticationPrincipal CustomUserDetails principal,
-            @PathVariable Long workflowId
+            @PathVariable Long artifactId
     ) {
-        User actor = principal.getUser();
-        var res = reactionService.likeWorkflow(actor, workflowId);
-        return ResponseEntity.ok(Response.success(res));
+        return ResponseEntity.ok(Response.success(
+                reactionService.likeArtifact(principal.getUser(), artifactId)
+        ));
     }
 
-    @Operation(summary = "워크플로우 좋아요 취소")
-    @DeleteMapping("/workflows/{workflowId}/like")
-    public ResponseEntity<Response<WorkflowLikeResponseDTO>> unlike(
+    @Operation(summary = "결과물 좋아요 취소", description = "멱등 — 이미 취소 상태면 그대로 반환")
+    @DeleteMapping("/artifacts/{artifactId}/like")
+    public ResponseEntity<Response<ArtifactLikeResponseDTO>> unlikeArtifact(
             @AuthenticationPrincipal CustomUserDetails principal,
-            @PathVariable Long workflowId
+            @PathVariable Long artifactId
     ) {
-        User actor = principal.getUser();
-        var res = reactionService.unlikeWorkflow(actor, workflowId);
-        return ResponseEntity.ok(Response.success(res));
+        return ResponseEntity.ok(Response.success(
+                reactionService.unlikeArtifact(principal.getUser(), artifactId)
+        ));
     }
 }

--- a/src/main/java/com/ayno/aynobe/dto/reaction/ArtifactLikeResponseDTO.java
+++ b/src/main/java/com/ayno/aynobe/dto/reaction/ArtifactLikeResponseDTO.java
@@ -8,14 +8,14 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-@Schema(name = "WorkflowLikeResponse")
-public class WorkflowLikeResponseDTO {
-    @Schema(description = "워크플로우 ID", example = "123")
-    private Long workflowId;
+@Schema(name = "ArtifactLikeResponse")
+public class ArtifactLikeResponseDTO {
+    @Schema(description = "결과물 ID", example = "1")
+    private Long artifactId;
 
     @Schema(description = "해당 사용자가 좋아요 눌렀는지", example = "true")
     private boolean liked;
 
     @Schema(description = "전체 좋아요 수", example = "42")
-    private long likeCount;
+    private Long likeCount;
 }

--- a/src/main/java/com/ayno/aynobe/repository/ArtifactRepository.java
+++ b/src/main/java/com/ayno/aynobe/repository/ArtifactRepository.java
@@ -6,10 +6,17 @@ import com.ayno.aynobe.entity.enums.VisibilityType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ArtifactRepository extends JpaRepository<Artifact, Long> {
     Page<Artifact> findByVisibility(VisibilityType visibility, Pageable pageable);
     Page<Artifact> findByVisibilityAndCategory(VisibilityType visibility, FlowType category, Pageable pageable);
     boolean existsBySlug(String slug);
     boolean existsBySlugAndArtifactIdNot(String slug, Long artifactId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("update Artifact a set a.likeCount = a.likeCount + :delta where a.artifactId = :artifactId")
+    int updateLikeCount(@Param("artifactId") Long artifactId, @Param("delta") long delta);
 }


### PR DESCRIPTION
## 요약

* **삭제**: 워크플로우 좋아요 API 3개 전부 제거.
* **추가**: 결과물(Artifact) 좋아요 API 3개 신규 생성(방금 구현).

---

## 변경 상세

### 1) 제거된 API (워크플로우용 3개)

* `GET    /api/reaction/workflows/{workflowId}/like` — 좋아요 상태 조회
* `POST   /api/reaction/workflows/{workflowId}/like` — 좋아요
* `DELETE /api/reaction/workflows/{workflowId}/like` — 좋아요 취소

> 관련 서비스/DTO/레포 보조 로직도 정리:
>
> * `ReactionService`의 `get/like/unlikeWorkflow` 제거
> * `WorkflowRepository.updateLikeCount(...)` 제거
> * `WorkflowLikeResponseDTO` 제거
> * Swagger 문서에서 워크플로우 좋아요 섹션 제거

### 2) 새로 추가된 API (결과물용 3개)

* `GET    /api/reaction/artifacts/{artifactId}/like` — 결과물 좋아요 상태 조회 (비로그인 가능)
* `POST   /api/reaction/artifacts/{artifactId}/like` — 결과물 좋아요 (USER, 멱등)
* `DELETE /api/reaction/artifacts/{artifactId}/like` — 결과물 좋아요 취소 (USER, 멱등)

> 구현 포인트:
>
> * Controller: 기존 `ReactionController`에 메서드 3개 **추가만** (컨트롤러 남발 X)
> * Service: `ArtifactReactionService` 신규(또는 기존 ReactionService 내 Artifact 전용 메서드)
>
>   * Reaction 저장/삭제, `ArtifactRepository.updateLikeCount(±1)`로 카운트 반영
>   * 멱등 처리: 이미 좋아요/취소 상태면 상태만 반환
> * DTO: `ArtifactLikeResponseDTO { artifactId, liked, likeCount }`

---

## 의도/배경

* 화면 설계상 워크플로우+결과물 동시 노출 시 **하트 중복** 혼선을 방지.
* 제품 규칙: **하트는 결과물(Artifact)만** 제공.

---

## 테스트 체크리스트

* [ ] `GET /api/reaction/artifacts/{id}/like` 비로그인 호출 가능
* [ ] `POST /api/reaction/artifacts/{id}/like` 두 번 눌러도 카운트 1회(멱등)
* [ ] `DELETE /api/reaction/artifacts/{id}/like` 두 번 취소해도 카운트 감소 없음(멱등)
* [ ] Swagger에 워크플로우 좋아요 3개 제거, 결과물 3개만 노출
* [ ] 기존 클라이언트에서 워크플로우 좋아요 호출 없도록 변경 확인

---

## 릴리즈 노트

* **Breaking**: 워크플로우 좋아요 API 3개 제거.
* **Added**: 결과물 좋아요 API 3개 신규.
  클라이언트는 모두 결과물 엔드포인트만 사용하세요.
