### PR TITLE
refactor: 썸네일 가져오기 추가

### DIFF
--- a/src/main/java/com/ayno/aynobe/dto/artifact/ArtifactListItemResponseDTO.java
+++ b/src/main/java/com/ayno/aynobe/dto/artifact/ArtifactListItemResponseDTO.java
@@ -14,6 +14,7 @@ import lombok.*;
 public class ArtifactListItemResponseDTO {
     private Long artifactId;
     private String artifactTitle;
+    private String thumbnailUrl;
     private Long userId;
     private String nickname;
     private String profileImageUrl;
@@ -33,6 +34,7 @@ public class ArtifactListItemResponseDTO {
         return ArtifactListItemResponseDTO.builder()
                 .artifactId(artifact.getArtifactId())
                 .artifactTitle(artifact.getArtifactTitle())
+                .thumbnailUrl(artifact.getThumbnailUrl())
                 .userId(artifact.getUser().getUserId())
                 .nickname(artifact.getUser().getNickname())
                 .profileImageUrl(artifact.getUser().getProfileImageUrl())

--- a/src/main/java/com/ayno/aynobe/service/ArtifactService.java
+++ b/src/main/java/com/ayno/aynobe/service/ArtifactService.java
@@ -194,7 +194,6 @@ public class ArtifactService {
             Pageable pageable
     ) {
         // 1. 정렬 조건 처리 (Pageable 객체 재생성)
-        // 프론트에서 "latest"라고 보내면 "createAt"으로, "popular"면 "likeCount"로 변환
         Pageable sortedPageable = PageRequest.of(
                 pageable.getPageNumber(),
                 pageable.getPageSize(),


### PR DESCRIPTION
## 📋 개요 (Background)
**목록 조회 API의 성능 이슈(N+1 문제)를 해결하기 위한 스키마 최적화 작업입니다.**

기존 구조에서는 `Artifact`(결과물) 목록을 조회할 때마다 썸네일을 찾기 위해 `ArtifactMedia` 테이블을 매번 JOIN하거나 서브쿼리로 조회해야 했습니다. 이는 메인 페이지 및 갤러리 뷰에서 불필요한 DB 부하를 발생시킵니다.

이를 해결하기 위해 **반정규화(Denormalization)** 전략을 도입하여, `Artifact` 테이블에 `thumbnailUrl` 컬럼을 추가하고 데이터 생성/수정 시점에 이를 동기화하도록 변경했습니다.

## 🧱 주요 변경 사항 (Changes)
### 1. Artifact Entity 수정
- **컬럼 추가**: `thumbnailUrl` (`VARCHAR(512)`) 컬럼을 추가했습니다.
- **도메인 로직 강화 (`addMediasFrom`, `replaceMediasFrom`)**:
  - 미디어 리스트가 저장될 때, `isCover=true`인 항목(없으면 첫 번째 항목)을 찾아 `thumbnailUrl` 필드에 자동으로 주입합니다.
  - 이를 통해 Service 계층의 비즈니스 로직 수정 없이, 엔티티 내부에서 상태 무결성을 보장합니다.

### 2. Response DTO 수정
- **ArtifactListItemResponseDTO**:
  - `thumbnailUrl` 필드를 추가했습니다.
  - 값이 없을 경우 `null`을 반환합니다 (프론트엔드에서 Default 이미지 처리).

## 💡 기술적 의사결정 (Technical Decisions)
1. **Service 로직 미변경 (DDD 적용)**
   - 썸네일을 선정하는 로직은 `Artifact` 도메인의 책임이라고 판단했습니다. 따라서 `ArtifactService`에 절차지향적인 코드를 추가하는 대신, 엔티티의 `add/replace` 메서드 내부에 로직을 캡슐화하여 유지보수성을 높였습니다.

2. **Null 반환 정책**
   - 썸네일이 없을 경우 서버에서 `"default.png"` 같은 더미 URL을 내려주는 대신 `null`을 반환합니다.
   - **이유**: 디자인 자산(Default Image)은 백엔드 데이터가 아닌 프론트엔드 UI/UX 영역이므로, 클라이언트 번들(`assets`)에서 관리하는 것이 트래픽 효율과 관리 측면에서 유리하기 때문입니다.

## ✅ 체크리스트 (Check List)
- [x] **[CREATE]** 새 결과물 생성 시, 지정한 커버 이미지가 `artifact` 테이블 `thumbnail_url` 컬럼에 잘 들어가는가?
- [ ] **[UPDATE]** 결과물 수정 시, 커버 이미지를 바꾸면 `thumbnail_url`도 즉시 갱신되는가?
- [x] **[READ]** `/api/artifacts` 목록 조회 시 JSON 응답에 `thumbnailUrl` 필드가 정상적으로 노출되는가?
- [x] **[NULL]** 이미지가 없는 게시글의 경우 `thumbnailUrl`이 `null`로 내려오는지 확인했는가?