### PR TITLE
feature : 통합 조회/검색 API와 강제 삭제 API제작

### DIFF
--- a/src/main/java/com/ayno/aynobe/config/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/ayno/aynobe/config/security/filter/JwtAuthenticationFilter.java
@@ -44,20 +44,17 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         String uri = request.getRequestURI();
 
-        // 1. 화이트리스트 및 이미 인증된 경우 패스
         if (isWhitelisted(uri) || isAlreadyAuthenticated()) {
             chain.doFilter(request, response);
             return;
         }
 
         try {
-            // 2. Access Token으로 인증 시도
             if (tryAccessTokenAuthentication(request, uri)) {
                 chain.doFilter(request, response);
                 return;
             }
 
-            // 3. Access 실패 시, Refresh Token으로 재발급 및 인증 시도
             if (tryRefreshTokenAuthentication(request, response, uri)) {
                 chain.doFilter(request, response);
                 return;
@@ -68,11 +65,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             return;
         }
 
-        // 4. 인증 실패했거나 토큰이 없는 경우 -> 익명 사용자로 다음 필터 진행
+        // 인증 실패했거나 토큰이 없는 경우 -> 익명 사용자로 다음 필터 진행
         chain.doFilter(request, response);
     }
 
-    // --- [Core Logic 1] Access Token 처리 ---
+    // --- Access Token 처리 ---
     private boolean tryAccessTokenAuthentication(HttpServletRequest request, String uri) {
         String token = resolveToken(request, uri, CookieFactory.ADMIN_ACCESS_COOKIE, CookieFactory.USER_ACCESS_COOKIE);
         if (token == null) return false;
@@ -91,7 +88,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         return false;
     }
 
-    // --- [Core Logic 2] Refresh Token 처리 (재발급) ---
+    // --- Refresh Token 처리 (재발급) ---
     private boolean tryRefreshTokenAuthentication(HttpServletRequest request, HttpServletResponse response, String uri) {
         String token = resolveToken(request, uri, CookieFactory.ADMIN_REFRESH_COOKIE, CookieFactory.USER_REFRESH_COOKIE);
         if (token == null) return false;
@@ -115,7 +112,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         return false;
     }
 
-    // --- [Helpers] ---
+    // --- Helpers ---
 
     private void reissueCookie(HttpServletResponse response, String accessToken, List<String> roles) {
         boolean isAdmin = roles != null && roles.contains("ROLE_ADMIN");

--- a/src/main/java/com/ayno/aynobe/controller/admin/AdminArtifactController.java
+++ b/src/main/java/com/ayno/aynobe/controller/admin/AdminArtifactController.java
@@ -1,9 +1,19 @@
 package com.ayno.aynobe.controller.admin;
 
+import com.ayno.aynobe.dto.admin.AdminArtifactResponseDTO;
+import com.ayno.aynobe.dto.common.PageResponseDTO;
+import com.ayno.aynobe.dto.common.Response;
+import com.ayno.aynobe.entity.enums.VisibilityType;
 import com.ayno.aynobe.service.admin.AdminArtifactService;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "AdminArtifact", description = "관리자 결과물 관리 API")
@@ -12,5 +22,15 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class AdminArtifactController {
     private final AdminArtifactService adminArtifactService;
+
+    @Operation(summary = "관리자 프로젝트 목록 조회", description = "ID검색, 상태필터, 제목/작성자 검색 통합")
+    @GetMapping
+    public ResponseEntity<Response<PageResponseDTO<AdminArtifactResponseDTO>>> getArtifacts(
+            @RequestParam(required = false) VisibilityType status,
+            @RequestParam(required = false, name = "q") String keyword, // 검색어 (ID or 텍스트)
+            @ParameterObject Pageable pageable
+    ) {
+        return ResponseEntity.ok(Response.success(adminArtifactService.getArtifacts(status, keyword, pageable)));
+    }
 
 }

--- a/src/main/java/com/ayno/aynobe/controller/admin/AdminArtifactController.java
+++ b/src/main/java/com/ayno/aynobe/controller/admin/AdminArtifactController.java
@@ -11,10 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "AdminArtifact", description = "관리자 결과물 관리 API")
 @RestController
@@ -31,6 +28,15 @@ public class AdminArtifactController {
             @ParameterObject Pageable pageable
     ) {
         return ResponseEntity.ok(Response.success(adminArtifactService.getArtifacts(status, keyword, pageable)));
+    }
+
+    @Operation(summary = "프로젝트 강제 삭제", description = "관리자 권한으로 DB에서 완전히 삭제합니다. (신고 내역도 같이 삭제됨)")
+    @DeleteMapping("/{artifactId}")
+    public ResponseEntity<?> deleteArtifact(
+            @PathVariable Long artifactId
+    ) {
+        adminArtifactService.deleteArtifact(artifactId);
+        return ResponseEntity.ok(Response.success("삭제되었습니다"));
     }
 
 }

--- a/src/main/java/com/ayno/aynobe/controller/admin/AdminArtifactController.java
+++ b/src/main/java/com/ayno/aynobe/controller/admin/AdminArtifactController.java
@@ -1,0 +1,16 @@
+package com.ayno.aynobe.controller.admin;
+
+import com.ayno.aynobe.service.admin.AdminArtifactService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "AdminArtifact", description = "관리자 결과물 관리 API")
+@RestController
+@RequestMapping("/api/admin/artifacts")
+@RequiredArgsConstructor
+public class AdminArtifactController {
+    private final AdminArtifactService adminArtifactService;
+
+}

--- a/src/main/java/com/ayno/aynobe/dto/admin/AdminArtifactResponseDTO.java
+++ b/src/main/java/com/ayno/aynobe/dto/admin/AdminArtifactResponseDTO.java
@@ -1,0 +1,43 @@
+package com.ayno.aynobe.dto.admin;
+
+import com.ayno.aynobe.entity.Artifact;
+import com.ayno.aynobe.entity.enums.VisibilityType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "관리자용 프로젝트 목록 응답 (썸네일 제외, 관리 정보 포함)")
+public class AdminArtifactResponseDTO {
+    private Long artifactId;
+    private String title;
+    private Long workflowId; // 워크플로우 연결 여부 확인용
+    private Long userId;
+    private String nickname;
+    private String username;
+    private VisibilityType visibility; // PUBLIC, PRIVATE
+    private Long viewCount;            // 영향력 파악용
+    private LocalDateTime createdAt;
+
+    // Entity -> DTO 변환 메서드
+    public static AdminArtifactResponseDTO from(Artifact artifact) {
+        return AdminArtifactResponseDTO.builder()
+                .artifactId(artifact.getArtifactId())
+                .title(artifact.getArtifactTitle())
+                .workflowId(artifact.getWorkflow() != null ? artifact.getWorkflow().getWorkflowId() : null)
+                .userId(artifact.getUser().getUserId())
+                .nickname(artifact.getUser().getNickname())
+                .username(artifact.getUser().getUsername())
+                .visibility(artifact.getVisibility())
+                .viewCount(artifact.getViewCount())
+                .createdAt(artifact.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/ayno/aynobe/dto/admin/AdminArtifactResponseDTO.java
+++ b/src/main/java/com/ayno/aynobe/dto/admin/AdminArtifactResponseDTO.java
@@ -17,7 +17,7 @@ import java.time.LocalDateTime;
 @Schema(description = "관리자용 프로젝트 목록 응답 (썸네일 제외, 관리 정보 포함)")
 public class AdminArtifactResponseDTO {
     private Long artifactId;
-    private String title;
+    private String artifactTitle;
     private Long workflowId; // 워크플로우 연결 여부 확인용
     private Long userId;
     private String nickname;
@@ -30,7 +30,7 @@ public class AdminArtifactResponseDTO {
     public static AdminArtifactResponseDTO from(Artifact artifact) {
         return AdminArtifactResponseDTO.builder()
                 .artifactId(artifact.getArtifactId())
-                .title(artifact.getArtifactTitle())
+                .artifactTitle(artifact.getArtifactTitle())
                 .workflowId(artifact.getWorkflow() != null ? artifact.getWorkflow().getWorkflowId() : null)
                 .userId(artifact.getUser().getUserId())
                 .nickname(artifact.getUser().getNickname())

--- a/src/main/java/com/ayno/aynobe/repository/ArtifactRepository.java
+++ b/src/main/java/com/ayno/aynobe/repository/ArtifactRepository.java
@@ -75,4 +75,23 @@ public interface ArtifactRepository extends JpaRepository<Artifact, Long> {
             @Param("keyword") String keyword,
             Pageable pageable
     );
+
+    @Query("SELECT a FROM Artifact a " +
+            "LEFT JOIN a.user u " + // 작성자 정보 검색을 위해 조인
+            "WHERE " +
+            "(:status IS NULL OR a.visibility = :status) AND " + // 상태 필터
+            "(" +
+            "   (:artifactId IS NOT NULL AND a.artifactId = :artifactId) OR " + // ID 검색
+            "   (:keyword IS NOT NULL AND (" +
+            "       a.artifactTitle LIKE CONCAT('%', :keyword, '%') OR " +      // 제목 검색
+            "       u.nickname LIKE CONCAT('%', :keyword, '%') OR " +   // 닉네임 검색
+            "       u.username LIKE CONCAT('%', :keyword, '%')" +          // 이메일 검색
+            "   )) OR " +
+            "   (:artifactId IS NULL AND :keyword IS NULL)" + // 검색어 없으면 전체
+            ")")
+    Page<Artifact> searchArtifactsForAdmin(
+            @Param("status") VisibilityType status,
+            @Param("artifactId") Long artifactId,
+            @Param("keyword") String keyword,
+            Pageable pageable);
 }

--- a/src/main/java/com/ayno/aynobe/repository/ReactionRepository.java
+++ b/src/main/java/com/ayno/aynobe/repository/ReactionRepository.java
@@ -23,4 +23,6 @@ public interface ReactionRepository extends JpaRepository<Reaction, Long> {
                                       @Param("targetType") TargetType targetType,
                                       @Param("targetId") Long targetId,
                                       @Param("reactionType") ReactionType reactionType);
+
+    void deleteByTargetIdAndTargetType(Long targetId, TargetType targetType);
 }

--- a/src/main/java/com/ayno/aynobe/repository/ReportRepository.java
+++ b/src/main/java/com/ayno/aynobe/repository/ReportRepository.java
@@ -26,4 +26,6 @@ public interface ReportRepository extends JpaRepository<Report, Long> {
             Pageable pageable);
 
     boolean existsByReporterAndTargetIdAndTargetType(User reporter, Long targetId, ReportTargetType targetType);
+
+    void deleteByTargetIdAndTargetType(Long targetId, ReportTargetType targetType);
 }

--- a/src/main/java/com/ayno/aynobe/service/ArtifactService.java
+++ b/src/main/java/com/ayno/aynobe/service/ArtifactService.java
@@ -8,10 +8,10 @@ import com.ayno.aynobe.entity.ArtifactMedia;
 import com.ayno.aynobe.entity.User;
 import com.ayno.aynobe.entity.Workflow;
 import com.ayno.aynobe.entity.enums.FlowType;
+import com.ayno.aynobe.entity.enums.ReportTargetType;
+import com.ayno.aynobe.entity.enums.TargetType;
 import com.ayno.aynobe.entity.enums.VisibilityType;
-import com.ayno.aynobe.repository.ArtifactRepository;
-import com.ayno.aynobe.repository.StepSectionRepository;
-import com.ayno.aynobe.repository.WorkflowRepository;
+import com.ayno.aynobe.repository.*;
 import com.ayno.aynobe.service.s3.S3Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -31,6 +31,8 @@ public class ArtifactService {
     private final ArtifactRepository artifactRepository;
     private final WorkflowRepository workflowRepository;
     private final StepSectionRepository stepSectionRepository;
+    private final ReportRepository reportRepository;
+    private final ReactionRepository reactionRepository;
     private final S3Service s3Service;
 
     public PageResponseDTO<ArtifactListItemResponseDTO> listPublic(
@@ -162,7 +164,7 @@ public class ArtifactService {
             throw CustomException.forbidden("본인이 등록한 결과물만 삭제할 수 있습니다.");
         }
 
-        // 1. S3 물리적 파일 삭제
+        // S3 물리적 파일 삭제
         Workflow workflow = artifact.getWorkflow();
         if (workflow != null) {
             Long workflowId = workflow.getWorkflowId();
@@ -179,7 +181,10 @@ public class ArtifactService {
             s3Service.deleteS3MediaSet(media.getBaseKey());
         }
 
-        // 2. DB 삭제
+        reportRepository.deleteByTargetIdAndTargetType(artifactId, ReportTargetType.ARTIFACT);
+
+        reactionRepository.deleteByTargetIdAndTargetType(artifactId, TargetType.ARTIFACT);
+
         artifactRepository.delete(artifact);
 
         return ArtifactDeleteResponseDTO.builder()

--- a/src/main/java/com/ayno/aynobe/service/ArtifactService.java
+++ b/src/main/java/com/ayno/aynobe/service/ArtifactService.java
@@ -173,10 +173,13 @@ public class ArtifactService {
             List<String> sectionBaseKeys = stepSectionRepository.findAllBaseKeysByWorkflowId(workflowId);
 
             for (String baseKey : sectionBaseKeys) {
-                s3Service.deleteS3MediaSet(baseKey);
+                if (baseKey != null && !baseKey.isBlank()) {
+                    s3Service.deleteS3MediaSet(baseKey);
+                }
             }
         }
 
+        // 아티팩트 본문 미디어 삭제
         for (ArtifactMedia media : artifact.getMedias()) {
             s3Service.deleteS3MediaSet(media.getBaseKey());
         }

--- a/src/main/java/com/ayno/aynobe/service/admin/AdminArtifactService.java
+++ b/src/main/java/com/ayno/aynobe/service/admin/AdminArtifactService.java
@@ -1,0 +1,7 @@
+package com.ayno.aynobe.service.admin;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class AdminArtifactService {
+}

--- a/src/main/java/com/ayno/aynobe/service/admin/AdminArtifactService.java
+++ b/src/main/java/com/ayno/aynobe/service/admin/AdminArtifactService.java
@@ -20,12 +20,12 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class AdminArtifactService {
     private final ArtifactRepository artifactRepository;
     private final ReportRepository reportRepository;
     private final ReactionRepository reactionRepository;
 
+    @Transactional(readOnly = true)
     public PageResponseDTO<AdminArtifactResponseDTO> getArtifacts(
             VisibilityType status,
             String keyword,
@@ -53,6 +53,7 @@ public class AdminArtifactService {
                 .build();
     }
 
+    @Transactional
     public void deleteArtifact(Long artifactId) {
         Artifact artifact = artifactRepository.findById(artifactId)
                 .orElseThrow(() -> CustomException.notFound("Artifact not found"));

--- a/src/main/java/com/ayno/aynobe/service/admin/AdminArtifactService.java
+++ b/src/main/java/com/ayno/aynobe/service/admin/AdminArtifactService.java
@@ -1,7 +1,50 @@
 package com.ayno.aynobe.service.admin;
 
+import com.ayno.aynobe.dto.admin.AdminArtifactResponseDTO;
+import com.ayno.aynobe.dto.admin.AdminUserResponseDTO;
+import com.ayno.aynobe.dto.common.PageResponseDTO;
+import com.ayno.aynobe.entity.Artifact;
+import com.ayno.aynobe.entity.enums.VisibilityType;
+import com.ayno.aynobe.repository.ArtifactRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class AdminArtifactService {
+    private final ArtifactRepository artifactRepository;
+
+    public PageResponseDTO<AdminArtifactResponseDTO> getArtifacts(
+            VisibilityType status,
+            String keyword,
+            Pageable pageable
+    ) {
+        // 숫자가 들어오면 ID로 인식
+        Long artifactId = null;
+        if (keyword != null && keyword.matches("^[0-9]+$")) {
+            artifactId = Long.parseLong(keyword);
+        }
+
+        Page<Artifact> artifactPage = artifactRepository.searchArtifactsForAdmin(status, artifactId, keyword, pageable);
+
+        List<AdminArtifactResponseDTO> content = artifactPage.getContent().stream()
+                .map(AdminArtifactResponseDTO::from)
+                .toList();
+
+        return PageResponseDTO.<AdminArtifactResponseDTO>builder()
+                .content(content)
+                .page(artifactPage.getNumber())
+                .size(artifactPage.getSize())
+                .totalElements(artifactPage.getTotalElements())
+                .totalPages(artifactPage.getTotalPages())
+                .hasNext(artifactPage.hasNext())
+                .build();
+    }
 }

--- a/src/main/java/com/ayno/aynobe/service/admin/AdminUserService.java
+++ b/src/main/java/com/ayno/aynobe/service/admin/AdminUserService.java
@@ -46,7 +46,7 @@ public class AdminUserService {
 
         List<AdminUserResponseDTO> content = userPage.getContent().stream()
                 .map(AdminUserResponseDTO::from)
-                .collect(Collectors.toList());
+                .toList();
 
         return PageResponseDTO.<AdminUserResponseDTO>builder()
                 .content(content)


### PR DESCRIPTION
## 📌 PR 요약
관리자 페이지(Admin)에서 프로젝트(Artifact)를 관리하기 위한 **통합 조회/검색 API**와 **강제 삭제 API**를 구현했습니다.
관리자 편의성을 위해 **ID/키워드 하이브리드 검색**을 지원하며, 삭제 시 **DB 데이터(신고, 좋아요)와 S3 물리 파일**까지 완벽하게 정리하도록 로직을 구성했습니다.

## 🛠️ 주요 변경 사항

### 1. 관리자용 프로젝트 목록 조회 API 구현 (`GET /api/admin/artifacts`)
- **하이브리드 검색 로직 적용:**
  - 검색어(`keyword`)가 **숫자**일 경우: `Artifact ID`로 정확하게 매핑하여 검색.
  - 검색어(`keyword`)가 **문자**일 경우: `제목`, `작성자 닉네임`, `이메일`에 포함(`LIKE`)된 결과 검색.
  - **장점:** 별도의 타입 선택 없이 하나의 검색창에서 모든 검색 니즈 충족.
- **Admin 전용 DTO (`AdminArtifactResponseDTO`):**
  - 관리 목적의 핵심 데이터(`artifactId`, `title`, `User Email`, `createdAt`, `deletedAt`, `viewCount`) 위주로 경량화.

### 2. 프로젝트 강제 삭제 API 구현 (`DELETE /api/admin/artifacts/{id}`)
- **Full Hard Delete (영구 삭제) 적용:**
  1. **S3 파일 삭제:** `Artifact` 및 연결된 `Workflow`의 모든 미디어 리소스(이미지/영상)를 물리적으로 삭제하여 스토리지 비용 절감.
  2. **DB 자식 데이터 정리:** `Report`, `Reaction` 등 연관 데이터를 선제적으로 삭제하여 FK 무결성 유지.
  3. **DB 본체 삭제:** 최종적으로 `Artifact` 레코드 삭제.
- **트랜잭션 보장:** `@Transactional`을 적용하여 삭제 프로세스 전체의 원자성 보장.

### 3. Repository 최적화 (`@Modifying`)
- `ReportRepository`, `ReactionRepository`에 Bulk Delete 쿼리 추가 (`@Modifying`).
- 불필요한 `SELECT` 없이 한 번의 쿼리로 삭제 처리.

### 4. 기타 버그 수정 및 스키마 보완
- **User 테이블 컬럼 추가:** `marketing_agreed` (Boolean), `marketing_agreed_at` (DateTime) 컬럼 누락 문제 해결.

## 💻 핵심 코드 리뷰

### AdminArtifactService.java (삭제 로직)
```java
@Transactional
public void deleteArtifact(Long artifactId) {
    Artifact artifact = artifactRepository.findById(artifactId)
            .orElseThrow(() -> CustomException.notFound("Artifact not found"));

    // 1. S3 물리 파일 삭제 (리소스 정리)
    cleanupS3Resources(artifact); // 내부 로직: 본문 미디어 + 워크플로우 미디어 삭제

    // 2. DB 자식 데이터(신고, 좋아요) 정리
    reportRepository.deleteByTargetIdAndTargetType(artifactId, ReportTargetType.ARTIFACT);
    reactionRepository.deleteByTargetIdAndTargetType(artifactId, TargetType.ARTIFACT);

    // 3. 게시글 본체 삭제
    artifactRepository.delete(artifact);
}