### PR TITLE
refactor : 메인 결과물 리스트 가져오기 및 검색 api 통합

### DIFF
--- a/src/main/java/com/ayno/aynobe/controller/ArtifactController.java
+++ b/src/main/java/com/ayno/aynobe/controller/ArtifactController.java
@@ -27,23 +27,8 @@ public class ArtifactController {
     private final ArtifactService artifactService;
     private final PublishService publishService;
 
-    @Operation(
-            summary = "공개 결과물 목록 조회",
-            description = "visibility=PUBLIC 결과물을 최신순으로 페이지네이션하여 반환")
-    @GetMapping
-    public ResponseEntity<Response<PageResponseDTO<ArtifactListItemResponseDTO>>> list(
-            @RequestParam(required = false) FlowType category,
-            @RequestParam(defaultValue = "0") int page,   // 0-base
-            @RequestParam(defaultValue = "12") int size,
-            @RequestParam(defaultValue = "createdAt,desc") String sort // createdAt|likeCount|viewCount
-    ) {
-        return ResponseEntity.ok(Response.success(
-                artifactService.listPublic(category, page, size, sort)
-        ));
-    }
-
     @Operation(summary = "메인 리스트 및 검색", description = "공개된(PUBLIC) 결과물만 조회합니다. 카테고리가 없으면 전체 조회입니다.")
-    @GetMapping("/search")
+    @GetMapping
     public ResponseEntity<Response<PageResponseDTO<ArtifactListItemResponseDTO>>> getArtifacts(
             @RequestParam(required = false) FlowType category,
             @RequestParam(required = false, name = "q") String keyword,
@@ -51,7 +36,7 @@ public class ArtifactController {
             @ParameterObject Pageable pageable
     ) {
         return ResponseEntity.ok(
-                Response.success(artifactService.searchPublicArtifacts(category, keyword, sort, pageable))
+                Response.success(artifactService.getPublicArtifacts(category, keyword, sort, pageable))
         );
     }
 

--- a/src/main/java/com/ayno/aynobe/controller/ArtifactController.java
+++ b/src/main/java/com/ayno/aynobe/controller/ArtifactController.java
@@ -42,6 +42,19 @@ public class ArtifactController {
         ));
     }
 
+    @Operation(summary = "메인 리스트 및 검색", description = "공개된(PUBLIC) 결과물만 조회합니다. 카테고리가 없으면 전체 조회입니다.")
+    @GetMapping("/search")
+    public ResponseEntity<Response<PageResponseDTO<ArtifactListItemResponseDTO>>> getArtifacts(
+            @RequestParam(required = false) FlowType category,
+            @RequestParam(required = false, name = "q") String keyword,
+            @RequestParam(required = false, defaultValue = "createdAt") String sort,
+            @ParameterObject Pageable pageable
+    ) {
+        return ResponseEntity.ok(
+                Response.success(artifactService.searchPublicArtifacts(category, keyword, sort, pageable))
+        );
+    }
+
     @Operation(
             summary = "결과물 상세 조회",
             description = "미디어(이미지/영상/파일) 포함")
@@ -110,19 +123,6 @@ public class ArtifactController {
     ) {
         var res = publishService.unpublishArtifact(principal.getUser(), artifactId);
         return ResponseEntity.ok(res);
-    }
-
-    @Operation(summary = "메인 리스트 및 검색", description = "공개된(PUBLIC) 결과물만 조회합니다. 카테고리가 없으면 전체 조회입니다.")
-    @GetMapping("/search")
-    public ResponseEntity<Response<PageResponseDTO<ArtifactListItemResponseDTO>>> getArtifacts(
-            @RequestParam(required = false) FlowType category, // null이면 전체(All)
-            @RequestParam(required = false, name = "q") String keyword,
-            @RequestParam(required = false, defaultValue = "createdAt") String sort,
-            @ParameterObject Pageable pageable
-    ) {
-        return ResponseEntity.ok(
-                Response.success(artifactService.searchPublicArtifacts(category, keyword, sort, pageable))
-        );
     }
 
 }

--- a/src/main/java/com/ayno/aynobe/repository/ArtifactRepository.java
+++ b/src/main/java/com/ayno/aynobe/repository/ArtifactRepository.java
@@ -66,10 +66,14 @@ public interface ArtifactRepository extends JpaRepository<Artifact, Long> {
     int increaseViewCount(Long artifactId);
 
     @Query("SELECT a FROM Artifact a " +
-            "JOIN FETCH a.user u " +  // N+1 방지: 작성자 정보 한 번에 로딩
-            "WHERE a.visibility = 'PUBLIC' " +
-            "AND (:category IS NULL OR a.category = :category) " +
-            "AND (:keyword IS NULL OR a.artifactTitle LIKE %:keyword%)") // 제목 검색
+            "LEFT JOIN a.user u " +
+            "WHERE " +
+            "a.visibility = 'PUBLIC' AND " +
+            "(:category IS NULL OR a.category = :category) AND " +
+            "(" +
+            "   :keyword IS NULL OR " +
+            "   a.artifactTitle LIKE CONCAT('%', :keyword, '%')" +// 작성자 검색
+            ")")
     Page<Artifact> searchPublic(
             @Param("category") FlowType category,
             @Param("keyword") String keyword,

--- a/src/main/java/com/ayno/aynobe/service/ArtifactService.java
+++ b/src/main/java/com/ayno/aynobe/service/ArtifactService.java
@@ -35,26 +35,7 @@ public class ArtifactService {
     private final ReactionRepository reactionRepository;
     private final S3Service s3Service;
 
-    public PageResponseDTO<ArtifactListItemResponseDTO> listPublic(
-            FlowType category, int page, int size, String sort
-    ) {
-        Pageable pageable = PageRequest.of(page, size, resolveSort(sort));
-
-        Page<Artifact> result = (category == null)
-                ? artifactRepository.findByVisibility(VisibilityType.PUBLIC, pageable)
-                : artifactRepository.findByVisibilityAndCategory(VisibilityType.PUBLIC, category, pageable);
-
-        return PageResponseDTO.<ArtifactListItemResponseDTO>builder()
-                .content(result.getContent().stream().map(ArtifactListItemResponseDTO::from).toList())
-                .page(result.getNumber())
-                .size(result.getSize())
-                .totalElements(result.getTotalElements())
-                .totalPages(result.getTotalPages())
-                .hasNext(result.hasNext())
-                .build();
-    }
-
-    public PageResponseDTO<ArtifactListItemResponseDTO> searchPublicArtifacts(
+    public PageResponseDTO<ArtifactListItemResponseDTO> getPublicArtifacts(
             FlowType category,
             String keyword,
             String sort,

--- a/src/main/java/com/ayno/aynobe/service/ArtifactService.java
+++ b/src/main/java/com/ayno/aynobe/service/ArtifactService.java
@@ -54,6 +54,35 @@ public class ArtifactService {
                 .build();
     }
 
+    public PageResponseDTO<ArtifactListItemResponseDTO> searchPublicArtifacts(
+            FlowType category,
+            String keyword,
+            String sort,
+            Pageable pageable
+    ) {
+        // 정렬 조건 처리
+        Pageable sortedPageable = PageRequest.of(
+                pageable.getPageNumber(),
+                pageable.getPageSize(),
+                resolveSort(sort)
+        );
+
+        Page<Artifact> artifactPage = artifactRepository.searchPublic(category, keyword, sortedPageable);
+
+        List<ArtifactListItemResponseDTO> content = artifactPage.getContent().stream()
+                .map(ArtifactListItemResponseDTO::from)
+                .toList();
+
+        return PageResponseDTO.<ArtifactListItemResponseDTO>builder()
+                .content(content)
+                .page(artifactPage.getNumber())
+                .size(artifactPage.getSize())
+                .totalElements(artifactPage.getTotalElements())
+                .totalPages(artifactPage.getTotalPages())
+                .hasNext(artifactPage.hasNext())
+                .build();
+    }
+
     @Transactional
     public ArtifactDetailResponseDTO getDetail(Long artifactId) {
         Artifact artifact = artifactRepository.findDetailById(artifactId)
@@ -192,35 +221,6 @@ public class ArtifactService {
 
         return ArtifactDeleteResponseDTO.builder()
                 .artifactId(artifactId)
-                .build();
-    }
-
-    public PageResponseDTO<ArtifactListItemResponseDTO> searchPublicArtifacts(
-            FlowType category,
-            String keyword,
-            String sort,
-            Pageable pageable
-    ) {
-        // 1. 정렬 조건 처리 (Pageable 객체 재생성)
-        Pageable sortedPageable = PageRequest.of(
-                pageable.getPageNumber(),
-                pageable.getPageSize(),
-                resolveSort(sort)
-        );
-
-        // 2. 검색 실행
-        Page<Artifact> result = artifactRepository.searchPublic(category, keyword, sortedPageable);
-
-        // 3. DTO 변환 (우리가 아까 만든 Light DTO 사용)
-        return PageResponseDTO.<ArtifactListItemResponseDTO>builder()
-                .content(result.getContent().stream()
-                        .map(ArtifactListItemResponseDTO::from)
-                        .toList())
-                .page(result.getNumber())
-                .size(result.getSize())
-                .totalElements(result.getTotalElements())
-                .totalPages(result.getTotalPages())
-                .hasNext(result.hasNext())
                 .build();
     }
 


### PR DESCRIPTION
## 📌 PR 요약
메인 페이지의 **결과물 목록 조회(List)**와 **검색(Search)** 기능을 하나의 API(`GET /api/artifacts`)로 통합했습니다.
프론트엔드 연동 복잡도를 낮추고, 검색 품질 향상을 위해 검색 대상을 **제목(Title)**으로 한정하여 노이즈를 제거했습니다.

## 🛠️ 주요 변경 사항

### 1. API 통합 및 엔드포인트 정리
- **기존:** `/api/artifacts` (전체 목록) + `/api/artifacts/search` (검색) → **이원화되어 비효율적.**
- **변경:** **`/api/artifacts`** (통합)
  - 파라미터(`q`, `category`, `sort`) 유무에 따라 **목록 조회, 필터링, 검색**을 단일 API에서 모두 처리합니다.
  - 기존의 `/search` 엔드포인트는 제거했습니다.

### 2. 검색 로직 최적화 (Title Only)
- **변경 전:** 제목 + 내용 + 작성자 닉네임 (검색 정확도 낮음, 의도치 않은 결과 노출)
- **변경 후:** **오직 '제목(Title)'만 검색**
  - 사용자가 프로젝트를 찾을 때 가장 직관적인 '제목' 매칭에 집중하여 검색 결과의 연관성(Relevance)을 높였습니다.

### 3. Repository 쿼리 간소화
- 불필요한 `JOIN` 조건(닉네임 검색용)을 제거하고 쿼리 성능을 최적화했습니다.
- `LEFT JOIN FETCH`를 유지하여 목록 조회 시 작성자 정보 로딩에 따른 **N+1 문제**를 방지했습니다.

## 💻 핵심 코드 리뷰

### ArtifactController.java (통합 API)
```java
@Operation(summary = "공개 결과물 목록 조회 (통합)", description = "검색어, 카테고리, 정렬 기능을 단일 API로 처리합니다.")
@GetMapping
public ResponseEntity<Response<PageResponseDTO<ArtifactListItemResponseDTO>>> getArtifacts(
        @RequestParam(required = false) FlowType category, // 카테고리 필터
        @RequestParam(required = false, name = "q") String keyword, // 검색어 (제목)
        @RequestParam(required = false, defaultValue = "createdAt") String sort, // 정렬
        @ParameterObject Pageable pageable
) {
    return ResponseEntity.ok(
            Response.success(artifactService.getPublicArtifacts(category, keyword, sort, pageable))
    );
}